### PR TITLE
Adding spring actuator endpoints

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,15 +30,11 @@ development_env_up:
 	@echo "<===|DEVOPS|===> [ENVIRONMENT] Bringing development environment UP"
 	@docker-compose -f $(docker_compose_development_file) up -d
 	@# TODO Clean this way of referencing the target name in future iterations
-	@rm -f development_env_down
-	@touch development_env_up
 
 development_env_down:
 	@echo "<===|DEVOPS|===> [ENVIRONMENT] Bringing development environment DOWN"
 	@docker-compose -f $(docker_compose_development_file) down
 	@# TODO Clean this way of referencing the target name in future iterations
-	@rm -f development_env_up
-	@touch development_env_down
 
 development_run_tests: development_env_up
 	@echo "<===|DEVOPS|===> [TESTS] Running Unit Tests"

--- a/pom.xml
+++ b/pom.xml
@@ -58,6 +58,21 @@
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-security</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-oauth2-resource-server</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/org/identifiers/cloud/ws/linkchecker/api/controllers/HealthApiController.java
+++ b/src/main/java/org/identifiers/cloud/ws/linkchecker/api/controllers/HealthApiController.java
@@ -2,6 +2,7 @@ package org.identifiers.cloud.ws.linkchecker.api.controllers;
 
 import org.identifiers.cloud.ws.linkchecker.api.models.HealthApiModel;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -17,6 +18,9 @@ import org.springframework.web.bind.annotation.RestController;
  */
 @RestController
 @RequestMapping("healthApi")
+@Deprecated
+@ConditionalOnProperty(value = "management.endpoint.health.enabled",
+    matchIfMissing = true, havingValue = "false")
 public class HealthApiController {
     @Autowired
     private HealthApiModel model;

--- a/src/main/java/org/identifiers/cloud/ws/linkchecker/api/models/HealthApiModel.java
+++ b/src/main/java/org/identifiers/cloud/ws/linkchecker/api/models/HealthApiModel.java
@@ -1,5 +1,7 @@
 package org.identifiers.cloud.ws.linkchecker.api.models;
 
+import org.identifiers.cloud.ws.linkchecker.api.controllers.HealthApiController;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.stereotype.Component;
 
 import java.util.UUID;
@@ -14,6 +16,8 @@ import java.util.UUID;
  * Health Check API Controller model.
  */
 @Component
+@Deprecated
+@ConditionalOnBean(HealthApiController.class)
 public class HealthApiModel {
     private static String runningSessionId = UUID.randomUUID().toString();
 

--- a/src/main/java/org/identifiers/cloud/ws/linkchecker/configuration/LinkCheckerSecurityConfiguration.java
+++ b/src/main/java/org/identifiers/cloud/ws/linkchecker/configuration/LinkCheckerSecurityConfiguration.java
@@ -1,0 +1,36 @@
+package org.identifiers.cloud.ws.linkchecker.configuration;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+
+@Configuration
+@EnableWebSecurity
+public class LinkCheckerSecurityConfiguration extends WebSecurityConfigurerAdapter {
+    @Value("${org.identifiers.cloud.ws.linkchecker.requiredrole}")
+    String requiredRole; // Assumed that user gets role directly
+
+    @Override
+    protected void configure(HttpSecurity http) throws Exception {
+       String aExp = String.format(
+                "isAuthenticated() and principal.claims['realm_access']['roles'].contains('%s')",
+                requiredRole
+        );
+
+        http.authorizeRequests()
+                .antMatchers("/actuator").access(aExp)
+                .antMatchers("/actuator/loggers/**").access(aExp)
+                .antMatchers("/management/flushLinkCheckingHistory").access(aExp)
+                .antMatchers(HttpMethod.GET, "/actuator/health/**").permitAll()
+                .antMatchers(HttpMethod.POST,"/getScoreFor*").permitAll()
+            .and()
+                .csrf().disable()
+                .logout().disable()
+                .formLogin().disable()
+                .anonymous().disable()
+                .oauth2ResourceServer().jwt();
+    }
+}

--- a/src/main/java/org/identifiers/cloud/ws/linkchecker/daemons/indicators/LinkCheckerHealthIndicator.java
+++ b/src/main/java/org/identifiers/cloud/ws/linkchecker/daemons/indicators/LinkCheckerHealthIndicator.java
@@ -1,0 +1,23 @@
+package org.identifiers.cloud.ws.linkchecker.daemons.indicators;
+
+import org.identifiers.cloud.ws.linkchecker.daemons.LinkChecker;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.actuate.autoconfigure.health.ConditionalOnEnabledHealthIndicator;
+import org.springframework.boot.actuate.health.Health;
+import org.springframework.boot.actuate.health.HealthIndicator;
+import org.springframework.stereotype.Component;
+
+@Component
+@ConditionalOnEnabledHealthIndicator("link-checker-thread")
+public class LinkCheckerHealthIndicator implements HealthIndicator {
+    @Autowired
+    LinkChecker linkChecker;
+
+    @Override
+    public Health health() {
+        if (linkChecker.isShutdown())
+            return Health.down().build();
+        else
+            return Health.up().build();
+    }
+}

--- a/src/main/java/org/identifiers/cloud/ws/linkchecker/daemons/indicators/PeriodicCheckRequesterResolutionBaseDataHealthIndicator.java
+++ b/src/main/java/org/identifiers/cloud/ws/linkchecker/daemons/indicators/PeriodicCheckRequesterResolutionBaseDataHealthIndicator.java
@@ -1,0 +1,24 @@
+package org.identifiers.cloud.ws.linkchecker.daemons.indicators;
+
+import org.identifiers.cloud.ws.linkchecker.daemons.PeriodicCheckRequesterResolutionBaseData;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.actuate.autoconfigure.health.ConditionalOnEnabledHealthIndicator;
+import org.springframework.boot.actuate.health.Health;
+import org.springframework.boot.actuate.health.HealthIndicator;
+import org.springframework.stereotype.Component;
+
+@Component
+@ConditionalOnEnabledHealthIndicator("periodic-checker-thread")
+public class PeriodicCheckRequesterResolutionBaseDataHealthIndicator implements HealthIndicator {
+
+    @Autowired
+    PeriodicCheckRequesterResolutionBaseData periodicCheckRequesterResolutionBaseData;
+
+    @Override
+    public Health health() {
+        if (periodicCheckRequesterResolutionBaseData.isShutdown())
+            return Health.down().build();
+        else
+            return Health.up().build();
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -23,3 +23,42 @@ org.identifiers.cloud.ws.linkchecker.daemon.linkchecker.waittime.polltimeout=${W
 
 # Link Check Results Time To Live (default = 7 days)
 org.identifiers.cloud.ws.linkchecker.backend.data.linkcheckresults.ttl.seconds=${WS_LINK_CHECKER_CONFIG_BACKEND_DATA_LINK_CHECK_RESULTS_TTL_SECONDS:604800}
+
+
+org.identifiers.cloud.ws.linkchecker.requiredrole=${WS_LINK_CHECKER_CONFIG_BACKEND_REQUIRED_ROLE:chad}
+spring.security.oauth2.resourceserver.jwt.issuer-uri=${WS_LINK_CHECKER_CONFIG_BACKEND_SERVICE_JWT_ISSUERURI:http://localkeycloak:8080/auth/realms/scratchpad}
+
+### Spring actuators
+management.endpoints.jmx.exposure.exclude=*
+management.endpoint.loggers.enabled=true
+management.endpoint.health.enabled=true
+management.endpoint.health.show-details=when_authorized
+management.endpoint.health.redis.enabled=true
+management.endpoint.health.diskspace.enabled=false
+management.endpoint.health.periodic-checker-thread.enabled=true
+management.endpoint.health.link-checker-thread.enabled=true
+
+management.endpoints.web.exposure.include=loggers,health
+r
+# Deactivations for peace of mind - likely unnecessary
+management.endpoint.auditevents.enabled=false
+management.endpoint.beans.enabled=false
+management.endpoint.caches.enabled=false
+management.endpoint.conditions.enabled=false
+management.endpoint.configprops.enabled=false
+management.endpoint.env.enabled=false
+management.endpoint.flyway.enabled=false
+management.endpoint.httptrace.enabled=false
+management.endpoint.info.enabled=false
+management.endpoint.integrationgraph.enabled=false
+management.endpoint.liquibase.enabled=false
+management.endpoint.metrics.enabled=false
+management.endpoint.mappings.enabled=false
+management.endpoint.scheduledtasks.enabled=false
+management.endpoint.sessions.enabled=false
+management.endpoint.shutdown.enabled=false
+management.endpoint.threaddump.enabled=false
+management.endpoint.heapdump.enabled=false
+management.endpoint.jolokia.enabled=false
+management.endpoint.logfile.enabled=false
+management.endpoint.prometheus.enabled=false


### PR DESCRIPTION
Replaced legacy health checkers for spring endpoint health check with custom indicators for the threads; Loggers endpoint enabled for production debug when needed; Added spring security for only authenticated users to access loggers actuator and management api
