### PR TITLE
IDENTIFIER-103 - Making validation more proactive & some minor refactoring for warnings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,13 +28,11 @@ deploy: clean container_production_push
 
 development_env_up:
 	@echo "<===|DEVOPS|===> [ENVIRONMENT] Bringing development environment UP"
-	@docker-compose -f $(docker_compose_development_file) up -d
-	@# TODO Clean this way of referencing the target name in future iterations
+	@docker compose -f $(docker_compose_development_file) up -d
 
 development_env_down:
 	@echo "<===|DEVOPS|===> [ENVIRONMENT] Bringing development environment DOWN"
-	@docker-compose -f $(docker_compose_development_file) down
-	@# TODO Clean this way of referencing the target name in future iterations
+	@docker compose -f $(docker_compose_development_file) down
 
 development_run_tests: development_env_up
 	@echo "<===|DEVOPS|===> [TESTS] Running Unit Tests"

--- a/docker-compose-development.yml
+++ b/docker-compose-development.yml
@@ -1,7 +1,6 @@
 # Development environment for working with the Link Checker service
 # Author: Manuel Bernal Llinares <mbdebian@gmail.com>
 # TODO This development environment is not fully functional, because the recommender depends on the very same service we're working on, and it will not escape it's container to connect to the host OS.
-version: "3.5"
 services:
     resolver:
         image: identifiersorg/cloud-ws-resolver

--- a/src/main/java/org/identifiers/cloud/ws/linkchecker/api/controllers/CurationController.java
+++ b/src/main/java/org/identifiers/cloud/ws/linkchecker/api/controllers/CurationController.java
@@ -1,0 +1,31 @@
+package org.identifiers.cloud.ws.linkchecker.api.controllers;
+
+import lombok.RequiredArgsConstructor;
+import org.identifiers.cloud.ws.linkchecker.api.models.LinkScoringApiModel;
+import org.identifiers.cloud.ws.linkchecker.services.HistoryTrackingServiceException;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Map;
+
+
+/**
+ * This is a temporary feature while we don't have a dedicated curation pipeline
+ */
+@RestController
+@RequiredArgsConstructor
+public class CurationController {
+    private final LinkScoringApiModel model;
+
+    @GetMapping("/getResourcesWithLowAvailability")
+    public ResponseEntity<Map<String, Float>> getResourcesWithLowAvailability(
+            @RequestParam(defaultValue="80", required=false) int minAvailability)
+    {
+        var response = model.getResourcesIdsWithAvailabilityLowerThan(minAvailability);
+        if (response.isEmpty()) {
+            return ResponseEntity.noContent().build();
+        } else {
+            return ResponseEntity.ok(response);
+        }
+    }
+}

--- a/src/main/java/org/identifiers/cloud/ws/linkchecker/api/controllers/LinkScoringApiController.java
+++ b/src/main/java/org/identifiers/cloud/ws/linkchecker/api/controllers/LinkScoringApiController.java
@@ -1,16 +1,13 @@
 package org.identifiers.cloud.ws.linkchecker.api.controllers;
 
+import lombok.RequiredArgsConstructor;
 import org.identifiers.cloud.ws.linkchecker.api.models.LinkScoringApiModel;
 import org.identifiers.cloud.ws.linkchecker.api.requests.ServiceRequestScoreProvider;
 import org.identifiers.cloud.ws.linkchecker.api.requests.ServiceRequestScoreResource;
 import org.identifiers.cloud.ws.linkchecker.api.requests.ServiceRequestScoring;
 import org.identifiers.cloud.ws.linkchecker.api.responses.ServiceResponseScoringRequest;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 /**
  * Project: link-checker
@@ -21,24 +18,24 @@ import org.springframework.web.bind.annotation.RestController;
  * ---
  */
 @RestController
+@RequiredArgsConstructor
 public class LinkScoringApiController {
-    @Autowired
-    private LinkScoringApiModel model;
+    private final LinkScoringApiModel model;
 
-    @RequestMapping(value = "/getScoreForUrl", method = RequestMethod.POST)
-    public ResponseEntity<?> getScoreForUrl(@RequestBody ServiceRequestScoring request) {
+    @PostMapping("/getScoreForUrl")
+    public ResponseEntity<ServiceResponseScoringRequest> getScoreForUrl(@RequestBody ServiceRequestScoring request) {
         ServiceResponseScoringRequest response = model.getScoreForUrl(request);
         return new ResponseEntity<>(response, response.getHttpStatus());
     }
 
-    @RequestMapping(value = "/getScoreForResolvedId", method = RequestMethod.POST)
-    public ResponseEntity<?> getScoreForResolvedId(@RequestBody ServiceRequestScoreResource request) {
+    @PostMapping("/getScoreForResolvedId")
+    public ResponseEntity<ServiceResponseScoringRequest> getScoreForResolvedId(@RequestBody ServiceRequestScoreResource request) {
         ServiceResponseScoringRequest response = model.getScoreForResolvedId(request);
         return new ResponseEntity<>(response, response.getHttpStatus());
     }
 
-    @RequestMapping(value = "/getScoreForProvider", method = RequestMethod.POST)
-    public ResponseEntity<?> getScoreForProvider(@RequestBody ServiceRequestScoreProvider request) {
+    @PostMapping("/getScoreForProvider")
+    public ResponseEntity<ServiceResponseScoringRequest> getScoreForProvider(@RequestBody ServiceRequestScoreProvider request) {
         ServiceResponseScoringRequest response = model.getScoreForProvider(request);
         return new ResponseEntity<>(response, response.getHttpStatus());
     }

--- a/src/main/java/org/identifiers/cloud/ws/linkchecker/api/controllers/ManagementApiController.java
+++ b/src/main/java/org/identifiers/cloud/ws/linkchecker/api/controllers/ManagementApiController.java
@@ -1,5 +1,6 @@
 package org.identifiers.cloud.ws.linkchecker.api.controllers;
 
+import lombok.RequiredArgsConstructor;
 import org.identifiers.cloud.ws.linkchecker.api.models.ManagementApiModel;
 import org.identifiers.cloud.ws.linkchecker.api.responses.ServiceResponseManagementRequest;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -19,14 +20,13 @@ import org.springframework.web.bind.annotation.RestController;
  * like flushing the link checking historical data.
  */
 @RestController
+@RequiredArgsConstructor
 @RequestMapping("/management")
 public class ManagementApiController {
-
-    @Autowired
-    private ManagementApiModel model;
+    private final ManagementApiModel model;
 
     @RequestMapping("flushLinkCheckingHistory")
-    public ResponseEntity<?> flushLinkCheckingHistory() {
+    public ResponseEntity<ServiceResponseManagementRequest> flushLinkCheckingHistory() {
         ServiceResponseManagementRequest response = model.flushLinkCheckingHistory();
         return new ResponseEntity<>(response, response.getHttpStatus());
     }

--- a/src/main/java/org/identifiers/cloud/ws/linkchecker/api/controllers/RestResponseEntityExceptionHandler.java
+++ b/src/main/java/org/identifiers/cloud/ws/linkchecker/api/controllers/RestResponseEntityExceptionHandler.java
@@ -1,9 +1,8 @@
 package org.identifiers.cloud.ws.linkchecker.api.controllers;
 
+import lombok.extern.slf4j.Slf4j;
 import org.identifiers.cloud.ws.linkchecker.api.ApiCentral;
 import org.identifiers.cloud.ws.linkchecker.api.responses.ServiceResponse;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -16,22 +15,21 @@ import java.text.SimpleDateFormat;
 import java.util.Calendar;
 
 
+@Slf4j
 @ControllerAdvice
 public class RestResponseEntityExceptionHandler extends ResponseEntityExceptionHandler {
-    private static final Logger logger = LoggerFactory.getLogger(RestResponseEntityExceptionHandler.class);
-
-    private static final SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd HH:mm");
+    private static final SimpleDateFormat SDF = new SimpleDateFormat("yyyy-MM-dd HH:mm");
     private static String now() {
         // Date for easier finding related entries in log files
         Calendar cal = Calendar.getInstance();
-        return sdf.format(cal.getTime());
+        return SDF.format(cal.getTime());
     }
 
     @ExceptionHandler(value = { RuntimeException.class })
     protected ResponseEntity<Object> handleConflict(RuntimeException ex, WebRequest request) {
         // Last hope for logging of unforeseen errors
         // Also a way to make all responses to be of type ServiceResponse
-        logger.error("Unforeseen exception", ex);
+        log.error("Unforeseen exception", ex);
         ServiceResponse<?> responseBody = new ServiceResponse<>()
                 .setApiVersion(ApiCentral.apiVersion)
                 .setErrorMessage(String.format("Unforeseen exception at %s: %s", now(), ex.getMessage()));

--- a/src/main/java/org/identifiers/cloud/ws/linkchecker/api/models/ManagementApiModel.java
+++ b/src/main/java/org/identifiers/cloud/ws/linkchecker/api/models/ManagementApiModel.java
@@ -1,5 +1,6 @@
 package org.identifiers.cloud.ws.linkchecker.api.models;
 
+import lombok.RequiredArgsConstructor;
 import org.identifiers.cloud.ws.linkchecker.api.responses.ServiceResponseManagementRequest;
 import org.identifiers.cloud.ws.linkchecker.api.responses.ServiceResponseManagementRequestPayload;
 import org.identifiers.cloud.ws.linkchecker.services.HistoryTrackingService;
@@ -21,11 +22,10 @@ import org.springframework.stereotype.Component;
  */
 @Component
 @Scope("prototype")
+@RequiredArgsConstructor
 public class ManagementApiModel {
     private static final Logger logger = LoggerFactory.getLogger(ManagementApiModel.class);
-
-    @Autowired
-    private HistoryTrackingService historyTrackingService;
+    private final HistoryTrackingService historyTrackingService;
 
     public ServiceResponseManagementRequest flushLinkCheckingHistory() {
         logger.warn("FLUSH REQUEST for link checking historical data");

--- a/src/main/java/org/identifiers/cloud/ws/linkchecker/api/models/ManagementApiModel.java
+++ b/src/main/java/org/identifiers/cloud/ws/linkchecker/api/models/ManagementApiModel.java
@@ -1,6 +1,5 @@
 package org.identifiers.cloud.ws.linkchecker.api.models;
 
-import lombok.RequiredArgsConstructor;
 import org.identifiers.cloud.ws.linkchecker.api.responses.ServiceResponseManagementRequest;
 import org.identifiers.cloud.ws.linkchecker.api.responses.ServiceResponseManagementRequestPayload;
 import org.identifiers.cloud.ws.linkchecker.services.HistoryTrackingService;
@@ -22,10 +21,10 @@ import org.springframework.stereotype.Component;
  */
 @Component
 @Scope("prototype")
-@RequiredArgsConstructor
 public class ManagementApiModel {
     private static final Logger logger = LoggerFactory.getLogger(ManagementApiModel.class);
-    private final HistoryTrackingService historyTrackingService;
+
+    private HistoryTrackingService historyTrackingService;
 
     public ServiceResponseManagementRequest flushLinkCheckingHistory() {
         logger.warn("FLUSH REQUEST for link checking historical data");
@@ -42,5 +41,10 @@ public class ManagementApiModel {
             response.getPayload().setMessage("An error occurred while trying to flush link checking historical data, but DON'T PANIC, we'll get back on track");
         }
         return response;
+    }
+
+    @Autowired
+    public void setHistoryTrackingService(HistoryTrackingService historyTrackingService) {
+        this.historyTrackingService = historyTrackingService;
     }
 }

--- a/src/main/java/org/identifiers/cloud/ws/linkchecker/api/requests/ScoringRequestPayload.java
+++ b/src/main/java/org/identifiers/cloud/ws/linkchecker/api/requests/ScoringRequestPayload.java
@@ -1,6 +1,9 @@
 package org.identifiers.cloud.ws.linkchecker.api.requests;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.experimental.Accessors;
 
 import java.io.Serializable;
 
@@ -12,6 +15,7 @@ import java.io.Serializable;
  * @author Manuel Bernal Llinares <mbdebian@gmail.com>
  * ---
  */
+@Getter @Setter @Accessors(chain = true)
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class ScoringRequestPayload implements Serializable {
     protected String url;
@@ -19,17 +23,5 @@ public class ScoringRequestPayload implements Serializable {
 
     public boolean getAccept401or403() {
         return accept401or403;
-    }
-    public ScoringRequestPayload setAccept401or403(boolean accept401or403) {
-        this.accept401or403 = accept401or403;
-        return this;
-    }
-
-    public String getUrl() {
-        return url;
-    }
-    public ScoringRequestPayload setUrl(String url) {
-        this.url = url;
-        return this;
     }
 }

--- a/src/main/java/org/identifiers/cloud/ws/linkchecker/api/requests/ScoringRequestWithIdPayload.java
+++ b/src/main/java/org/identifiers/cloud/ws/linkchecker/api/requests/ScoringRequestWithIdPayload.java
@@ -1,6 +1,9 @@
 package org.identifiers.cloud.ws.linkchecker.api.requests;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.experimental.Accessors;
 
 import java.io.Serializable;
 
@@ -13,15 +16,7 @@ import java.io.Serializable;
  * ---
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
+@Getter @Setter @Accessors(chain = true)
 public class ScoringRequestWithIdPayload extends ScoringRequestPayload implements Serializable {
     private String id;
-
-    public String getId() {
-        return id;
-    }
-
-    public ScoringRequestWithIdPayload setId(String id) {
-        this.id = id;
-        return this;
-    }
 }

--- a/src/main/java/org/identifiers/cloud/ws/linkchecker/api/requests/ServiceRequest.java
+++ b/src/main/java/org/identifiers/cloud/ws/linkchecker/api/requests/ServiceRequest.java
@@ -1,6 +1,9 @@
 package org.identifiers.cloud.ws.linkchecker.api.requests;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.experimental.Accessors;
 
 import java.io.Serializable;
 
@@ -12,26 +15,9 @@ import java.io.Serializable;
  * @author Manuel Bernal Llinares <mbdebian@gmail.com>
  * ---
  */
+@Getter @Setter @Accessors(chain = true)
 @JsonIgnoreProperties(ignoreUnknown = true)
-public class ServiceRequest<T> implements Serializable {
+public class ServiceRequest<T extends Serializable> implements Serializable {
     private String apiVersion;
     private T payload;
-
-    public String getApiVersion() {
-        return apiVersion;
-    }
-
-    public ServiceRequest<T> setApiVersion(String apiVersion) {
-        this.apiVersion = apiVersion;
-        return this;
-    }
-
-    public T getPayload() {
-        return payload;
-    }
-
-    public ServiceRequest<T> setPayload(T payload) {
-        this.payload = payload;
-        return this;
-    }
 }

--- a/src/main/java/org/identifiers/cloud/ws/linkchecker/api/responses/ServiceResponse.java
+++ b/src/main/java/org/identifiers/cloud/ws/linkchecker/api/responses/ServiceResponse.java
@@ -1,6 +1,9 @@
 package org.identifiers.cloud.ws.linkchecker.api.responses;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.experimental.Accessors;
 import org.springframework.http.HttpStatus;
 
 import java.io.Serializable;
@@ -13,47 +16,12 @@ import java.io.Serializable;
  * @author Manuel Bernal Llinares <mbdebian@gmail.com>
  * ---
  */
+@Getter @Setter @Accessors(chain = true)
 @JsonIgnoreProperties(value = {"httpStatus"})
-public class ServiceResponse<T> implements Serializable {
+public class ServiceResponse<T extends Serializable> implements Serializable {
     private String apiVersion;
     private String errorMessage;
     private HttpStatus httpStatus = HttpStatus.OK;
     // payload
     private T payload;
-
-    public String getApiVersion() {
-        return apiVersion;
-    }
-
-    public ServiceResponse<T> setApiVersion(String apiVersion) {
-        this.apiVersion = apiVersion;
-        return this;
-    }
-
-    public String getErrorMessage() {
-        return errorMessage;
-    }
-
-    public ServiceResponse<T> setErrorMessage(String errorMessage) {
-        this.errorMessage = errorMessage;
-        return this;
-    }
-
-    public HttpStatus getHttpStatus() {
-        return httpStatus;
-    }
-
-    public ServiceResponse<T> setHttpStatus(HttpStatus httpStatus) {
-        this.httpStatus = httpStatus;
-        return this;
-    }
-
-    public T getPayload() {
-        return payload;
-    }
-
-    public ServiceResponse<T> setPayload(T payload) {
-        this.payload = payload;
-        return this;
-    }
 }

--- a/src/main/java/org/identifiers/cloud/ws/linkchecker/api/responses/ServiceResponseManagementRequestPayload.java
+++ b/src/main/java/org/identifiers/cloud/ws/linkchecker/api/responses/ServiceResponseManagementRequestPayload.java
@@ -1,5 +1,9 @@
 package org.identifiers.cloud.ws.linkchecker.api.responses;
 
+import lombok.Getter;
+import lombok.Setter;
+import lombok.experimental.Accessors;
+
 import java.io.Serializable;
 
 /**
@@ -12,15 +16,7 @@ import java.io.Serializable;
  *
  * This is a generic payload for management requests.
  */
+@Getter @Setter @Accessors(chain = true)
 public class ServiceResponseManagementRequestPayload implements Serializable {
     private String message = "";
-
-    public String getMessage() {
-        return message;
-    }
-
-    public ServiceResponseManagementRequestPayload setMessage(String message) {
-        this.message = message;
-        return this;
-    }
 }

--- a/src/main/java/org/identifiers/cloud/ws/linkchecker/api/responses/ServiceResponseScoringRequestPayload.java
+++ b/src/main/java/org/identifiers/cloud/ws/linkchecker/api/responses/ServiceResponseScoringRequestPayload.java
@@ -1,5 +1,9 @@
 package org.identifiers.cloud.ws.linkchecker.api.responses;
 
+import lombok.Getter;
+import lombok.Setter;
+import lombok.experimental.Accessors;
+
 import java.io.Serializable;
 
 /**
@@ -12,16 +16,8 @@ import java.io.Serializable;
  *
  * Response to a Scoring request
  */
+@Getter @Setter @Accessors(chain = true)
 public class ServiceResponseScoringRequestPayload implements Serializable {
     // Default scoring
     private int score = 50;
-
-    public int getScore() {
-        return score;
-    }
-
-    public ServiceResponseScoringRequestPayload setScore(int score) {
-        this.score = score;
-        return this;
-    }
 }

--- a/src/main/java/org/identifiers/cloud/ws/linkchecker/channels/management/flushhistorytrackingdata/FlushHistoryTrackingDataPublisher.java
+++ b/src/main/java/org/identifiers/cloud/ws/linkchecker/channels/management/flushhistorytrackingdata/FlushHistoryTrackingDataPublisher.java
@@ -1,5 +1,6 @@
 package org.identifiers.cloud.ws.linkchecker.channels.management.flushhistorytrackingdata;
 
+import lombok.RequiredArgsConstructor;
 import org.identifiers.cloud.ws.linkchecker.channels.Publisher;
 import org.identifiers.cloud.ws.linkchecker.data.models.FlushHistoryTrackingDataMessage;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -16,12 +17,10 @@ import org.springframework.stereotype.Component;
  * ---
  */
 @Component
+@RequiredArgsConstructor
 public class FlushHistoryTrackingDataPublisher extends Publisher<String, FlushHistoryTrackingDataMessage> {
-    @Autowired
-    private RedisTemplate<String, FlushHistoryTrackingDataMessage> flushHistoryTrackingDataMessageRedisTemplate;
-
-    @Autowired
-    private ChannelTopic channelTopicFlushHistoryTrackingData;
+    private final RedisTemplate<String, FlushHistoryTrackingDataMessage> flushHistoryTrackingDataMessageRedisTemplate;
+    private final ChannelTopic channelTopicFlushHistoryTrackingData;
 
     @Override
     protected ChannelTopic getChannelTopic() {

--- a/src/main/java/org/identifiers/cloud/ws/linkchecker/channels/management/flushhistorytrackingdata/FlushHistoryTrackingDataSubscriber.java
+++ b/src/main/java/org/identifiers/cloud/ws/linkchecker/channels/management/flushhistorytrackingdata/FlushHistoryTrackingDataSubscriber.java
@@ -1,5 +1,6 @@
 package org.identifiers.cloud.ws.linkchecker.channels.management.flushhistorytrackingdata;
 
+import lombok.RequiredArgsConstructor;
 import org.identifiers.cloud.ws.linkchecker.channels.Subscriber;
 import org.identifiers.cloud.ws.linkchecker.data.models.FlushHistoryTrackingDataMessage;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -19,19 +20,11 @@ import jakarta.annotation.PostConstruct;
  * ---
  */
 @Component
+@RequiredArgsConstructor
 public class FlushHistoryTrackingDataSubscriber extends Subscriber<String, FlushHistoryTrackingDataMessage> {
     private final RedisMessageListenerContainer redisContainer;
     private final ChannelTopic channelTopicFlushHistoryTrackingData;
     private final RedisTemplate<String, FlushHistoryTrackingDataMessage> flushHistoryTrackingDataMessageRedisTemplate;
-
-    public FlushHistoryTrackingDataSubscriber(
-            @Autowired RedisMessageListenerContainer redisContainer,
-            @Autowired ChannelTopic channelTopicFlushHistoryTrackingData,
-            @Autowired RedisTemplate<String, FlushHistoryTrackingDataMessage> flushHistoryTrackingDataMessageRedisTemplate) {
-        this.redisContainer = redisContainer;
-        this.channelTopicFlushHistoryTrackingData = channelTopicFlushHistoryTrackingData;
-        this.flushHistoryTrackingDataMessageRedisTemplate = flushHistoryTrackingDataMessageRedisTemplate;
-    }
 
     @PostConstruct
     public void registerSubscriber() {

--- a/src/main/java/org/identifiers/cloud/ws/linkchecker/configuration/LinkCheckResultConfig.java
+++ b/src/main/java/org/identifiers/cloud/ws/linkchecker/configuration/LinkCheckResultConfig.java
@@ -1,4 +1,4 @@
-package org.identifiers.cloud.ws.linkchecker.data.models;
+package org.identifiers.cloud.ws.linkchecker.configuration;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/src/main/java/org/identifiers/cloud/ws/linkchecker/configuration/PeriodicTasksConfiguration.java
+++ b/src/main/java/org/identifiers/cloud/ws/linkchecker/configuration/PeriodicTasksConfiguration.java
@@ -14,6 +14,7 @@ import org.springframework.scheduling.config.ScheduledTaskRegistrar;
 import java.time.Instant;
 import java.util.Optional;
 import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
 @Configuration
@@ -31,9 +32,9 @@ public class PeriodicTasksConfiguration implements SchedulingConfigurer {
     }
 
 
-    @Bean
-    public Executor taskExecutor() {
-        return Executors.newFixedThreadPool(2);
+    @Bean(destroyMethod="shutdown")
+    public ExecutorService taskExecutor() {
+        return Executors.newScheduledThreadPool(2);
     }
 
 

--- a/src/main/java/org/identifiers/cloud/ws/linkchecker/data/models/LinkCheckRequest.java
+++ b/src/main/java/org/identifiers/cloud/ws/linkchecker/data/models/LinkCheckRequest.java
@@ -1,5 +1,12 @@
 package org.identifiers.cloud.ws.linkchecker.data.models;
 
+import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.experimental.Accessors;
+
+import java.io.Serial;
 import java.io.Serializable;
 import java.util.Date;
 import java.sql.Timestamp;
@@ -14,7 +21,11 @@ import java.sql.Timestamp;
  *
  * This model represents a request for checking a link
  */
+@Getter @Setter @EqualsAndHashCode @Accessors(chain = true)
 public class LinkCheckRequest implements Serializable, Comparable<LinkCheckRequest> {
+    @Serial
+    private static final long serialVersionUID = 8460578676300241510L;
+
     // URL that has been checked
     private String url;
     // When it has been checked (UTC)
@@ -22,56 +33,16 @@ public class LinkCheckRequest implements Serializable, Comparable<LinkCheckReque
     // Link check request type / reference
     private String providerId;
     private String resourceId;
+
+    @Getter(AccessLevel.NONE)
     private boolean accept401or403 = false;
 
     public boolean shouldAccept401or403() {
         return accept401or403;
     }
 
-    public LinkCheckRequest setAccept401or403(boolean accept401or403) {
-        this.accept401or403 = accept401or403;
-        return this;
-    }
-
-    public String getUrl() {
-        return url;
-    }
-
-    public LinkCheckRequest setUrl(String url) {
-        this.url = url;
-        return this;
-    }
-
-    public Timestamp getTimestamp() {
-        return timestamp;
-    }
-
-    public LinkCheckRequest setTimestamp(Timestamp timestamp) {
-        this.timestamp = timestamp;
-        return this;
-    }
-
-    public String getProviderId() {
-        return providerId;
-    }
-
-    public LinkCheckRequest setProviderId(String providerId) {
-        this.providerId = providerId;
-        return this;
-    }
-
-    public String getResourceId() {
-        return resourceId;
-    }
-
-    public LinkCheckRequest setResourceId(String resourceId) {
-        this.resourceId = resourceId;
-        return this;
-    }
-
     @Override
     public int compareTo(LinkCheckRequest o) {
         return this.timestamp.compareTo(o.getTimestamp());
     }
-
 }

--- a/src/main/java/org/identifiers/cloud/ws/linkchecker/data/models/LinkCheckResult.java
+++ b/src/main/java/org/identifiers/cloud/ws/linkchecker/data/models/LinkCheckResult.java
@@ -1,10 +1,15 @@
 package org.identifiers.cloud.ws.linkchecker.data.models;
 
+import lombok.Getter;
+import lombok.Setter;
+import lombok.experimental.Accessors;
+import org.identifiers.cloud.ws.linkchecker.configuration.LinkCheckResultConfig;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.redis.core.RedisHash;
 import org.springframework.data.redis.core.TimeToLive;
 import org.springframework.data.redis.core.index.Indexed;
 
+import java.io.Serial;
 import java.io.Serializable;
 import java.sql.Timestamp;
 import java.util.Date;
@@ -19,8 +24,12 @@ import java.util.Date;
  *
  * This entity models a checked URL, for either a provider, a resource or a plain URL.
  */
+@Getter @Setter @Accessors(chain = true)
 @RedisHash(value = "LinkCheckerLinkCheckResult")
 public class LinkCheckResult implements Serializable, Comparable<LinkCheckResult> {
+    @Serial
+    private static final long serialVersionUID = -7180056948087986389L;
+
     // TTL as property
     @TimeToLive private Long timeToLive = LinkCheckResultConfig.timeToLive;
     // Result ID, hopefully manufactured by Redis
@@ -45,84 +54,15 @@ public class LinkCheckResult implements Serializable, Comparable<LinkCheckResult
     // lead to a non-error resource, and it is calculated by the link checking strategy used.
     private boolean urlAssessmentOk = false;
 
-    public Long getTimeToLive() {
-        return timeToLive;
-    }
-
-    public void setTimeToLive(Long ttl) {
-        timeToLive = ttl;
-    }
-
-    public String getId() {
-        return id;
-    }
-
-    public LinkCheckResult setId(String id) {
-        this.id = id;
-        return this;
-    }
-
-    public String getUrl() {
-        return url;
-    }
-
-    public LinkCheckResult setUrl(String url) {
-        this.url = url;
-        return this;
-    }
-
-    public Timestamp getTimestamp() {
-        return Timestamp.valueOf(timestamp);
-    }
-
-    public LinkCheckResult setTimestamp(Timestamp timestamp) {
-        this.timestamp = timestamp.toString();
-        return this;
-    }
-
-    public Timestamp getRequestTimestamp() {
-        return Timestamp.valueOf(requestTimestamp);
-    }
-
     public LinkCheckResult setRequestTimestamp(Timestamp requestTimestamp) {
         this.requestTimestamp = requestTimestamp.toString();
         return this;
     }
-
-    public String getProviderId() {
-        return providerId;
+    public Timestamp getRequestTimestamp() {
+        return Timestamp.valueOf(requestTimestamp);
     }
-
-    public LinkCheckResult setProviderId(String providerId) {
-        this.providerId = providerId;
-        return this;
-    }
-
-    public String getResourceId() {
-        return resourceId;
-    }
-
-    public LinkCheckResult setResourceId(String resourceId) {
-        this.resourceId = resourceId;
-        return this;
-    }
-
-    public int getHttpStatus() {
-        return httpStatus;
-    }
-
-    public LinkCheckResult setHttpStatus(int httpStatus) {
-        this.httpStatus = httpStatus;
-        return this;
-    }
-
-    public boolean isUrlAssessmentOk() {
-        return urlAssessmentOk;
-    }
-
-    public LinkCheckResult setUrlAssessmentOk(boolean urlAssessmentOk) {
-        this.urlAssessmentOk = urlAssessmentOk;
-        return this;
+    public Timestamp getTimestamp() {
+        return Timestamp.valueOf(requestTimestamp);
     }
 
     @Override

--- a/src/main/java/org/identifiers/cloud/ws/linkchecker/data/models/TrackedProvider.java
+++ b/src/main/java/org/identifiers/cloud/ws/linkchecker/data/models/TrackedProvider.java
@@ -1,9 +1,13 @@
 package org.identifiers.cloud.ws.linkchecker.data.models;
 
+import lombok.Getter;
+import lombok.Setter;
+import lombok.experimental.Accessors;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.redis.core.RedisHash;
 import org.springframework.data.redis.core.index.Indexed;
 
+import java.io.Serial;
 import java.io.Serializable;
 import java.sql.Timestamp;
 import java.util.Date;
@@ -18,8 +22,12 @@ import java.util.Date;
  * <p>
  * This models a provider being tracked by the service.
  */
+@Getter @Setter @Accessors(chain = true)
 @RedisHash("LinkCheckerTrackedProvider")
 public class TrackedProvider implements Serializable {
+    @Serial
+    private static final long serialVersionUID = 8616696712787060386L;
+
     // Provider ID within the context of a namespace or prefix
     @Id
     private String id;
@@ -29,24 +37,6 @@ public class TrackedProvider implements Serializable {
     // When the tracking was queued / added to the link checker (UTC)
     @Indexed
     private String created = (new Timestamp(new Date().getTime())).toString();
-
-    public String getId() {
-        return id;
-    }
-
-    public TrackedProvider setId(String id) {
-        this.id = id;
-        return this;
-    }
-
-    public String getUrl() {
-        return url;
-    }
-
-    public TrackedProvider setUrl(String url) {
-        this.url = url;
-        return this;
-    }
 
     public Timestamp getCreated() {
         return Timestamp.valueOf(created);

--- a/src/main/java/org/identifiers/cloud/ws/linkchecker/data/models/TrackedResource.java
+++ b/src/main/java/org/identifiers/cloud/ws/linkchecker/data/models/TrackedResource.java
@@ -1,9 +1,13 @@
 package org.identifiers.cloud.ws.linkchecker.data.models;
 
+import lombok.Getter;
+import lombok.Setter;
+import lombok.experimental.Accessors;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.redis.core.RedisHash;
 import org.springframework.data.redis.core.index.Indexed;
 
+import java.io.Serial;
 import java.io.Serializable;
 import java.sql.Timestamp;
 import java.util.Date;
@@ -19,8 +23,11 @@ import java.util.Date;
  * This models a resource being tracked by the service. A resource provides information on a given Compact ID, and the
  * URL is a resolved URL given that Compact ID.
  */
+@Getter @Setter @Accessors(chain = true)
 @RedisHash("LinkCheckerTrackedResource")
 public class TrackedResource implements Serializable {
+    @Serial
+    private static final long serialVersionUID = -8415715191054737703L;
 
     // Resource ID within the context of a namespace / prefix
     @Id
@@ -31,24 +38,6 @@ public class TrackedResource implements Serializable {
     // When the tracking was queued / added to the link checker (UTC)
     @Indexed
     private String created = (new Timestamp(new Date().getTime())).toString();
-
-    public String getId() {
-        return id;
-    }
-
-    public TrackedResource setId(String id) {
-        this.id = id;
-        return this;
-    }
-
-    public String getUrl() {
-        return url;
-    }
-
-    public TrackedResource setUrl(String url) {
-        this.url = url;
-        return this;
-    }
 
     public Timestamp getCreated() {
         return Timestamp.valueOf(created);

--- a/src/main/java/org/identifiers/cloud/ws/linkchecker/listeners/FlushHistoryTrackingDataListener.java
+++ b/src/main/java/org/identifiers/cloud/ws/linkchecker/listeners/FlushHistoryTrackingDataListener.java
@@ -1,5 +1,6 @@
 package org.identifiers.cloud.ws.linkchecker.listeners;
 
+import lombok.RequiredArgsConstructor;
 import org.identifiers.cloud.ws.linkchecker.channels.Listener;
 import org.identifiers.cloud.ws.linkchecker.channels.management.flushhistorytrackingdata
         .FlushHistoryTrackingDataSubscriber;
@@ -22,14 +23,12 @@ import jakarta.annotation.PostConstruct;
  * ---
  */
 @Component
+@RequiredArgsConstructor
 public class FlushHistoryTrackingDataListener implements Listener<FlushHistoryTrackingDataMessage> {
     private static final Logger logger = LoggerFactory.getLogger(FlushHistoryTrackingDataListener.class);
 
-    @Autowired
-    private FlushHistoryTrackingDataSubscriber subscriber;
-
-    @Autowired
-    private HistoryTrackingService historyTrackingService;
+    private final FlushHistoryTrackingDataSubscriber subscriber;
+    private final HistoryTrackingService historyTrackingService;
 
     @PostConstruct
     private void init() {

--- a/src/main/java/org/identifiers/cloud/ws/linkchecker/models/CheckedUrlHistoryStats.java
+++ b/src/main/java/org/identifiers/cloud/ws/linkchecker/models/CheckedUrlHistoryStats.java
@@ -29,5 +29,5 @@ public interface CheckedUrlHistoryStats {
      * Get the percentage of events where the checked URL was considered to be up and running
      * @return up and running percentage
      */
-    double getUpPercentage();
+    float getUpPercentage();
 }

--- a/src/main/java/org/identifiers/cloud/ws/linkchecker/models/CheckedUrlHistoryStatsSimple.java
+++ b/src/main/java/org/identifiers/cloud/ws/linkchecker/models/CheckedUrlHistoryStatsSimple.java
@@ -18,9 +18,9 @@ import java.util.List;
 public class CheckedUrlHistoryStatsSimple implements CheckedUrlHistoryStats, Serializable {
     private static final Logger logger = LoggerFactory.getLogger(CheckedUrlHistoryStatsSimple.class);
     // Number of events where the checked URL was considered to be up
-    private int nUpEvents = 0;
+    private long nUpEvents = 0;
     // Number of events where the checked URL was considered to be down
-    private int nDownEvents = 0;
+    private long nDownEvents = 0;
 
     public CheckedUrlHistoryStatsSimple() {
         logger.info("CheckedUrlHistoryStatsSimple instantiated");
@@ -46,11 +46,11 @@ public class CheckedUrlHistoryStatsSimple implements CheckedUrlHistoryStats, Ser
     }
 
     @Override
-    public double getUpPercentage() {
-        int nEvents = nDownEvents + nUpEvents;
+    public float getUpPercentage() {
+        long nEvents = nDownEvents + nUpEvents;
         if (nEvents == 0) {
-            return 50.0;
+            return 50.0f;
         }
-        return(nUpEvents * 100.0) / nEvents;
+        return (nUpEvents * 100.0f) / nEvents;
     }
 }

--- a/src/main/java/org/identifiers/cloud/ws/linkchecker/models/HistoryTracker.java
+++ b/src/main/java/org/identifiers/cloud/ws/linkchecker/models/HistoryTracker.java
@@ -1,7 +1,11 @@
 package org.identifiers.cloud.ws.linkchecker.models;
 
+import lombok.Getter;
+import lombok.Setter;
+import lombok.experimental.Accessors;
 import org.identifiers.cloud.ws.linkchecker.data.models.LinkCheckResult;
 
+import java.io.Serial;
 import java.io.Serializable;
 import java.sql.Timestamp;
 import java.util.*;
@@ -18,73 +22,47 @@ import java.util.stream.Collectors;
  *
  * This is a local cache for the history tracking information on a link. Base class for the different tracked entities.
  */
+@Getter @Setter @Accessors(chain = true)
 public abstract class HistoryTracker implements Serializable {
+    @Serial
+    private static final long serialVersionUID = 1946649288954507733L;
+
+
     // Home URL for this provider within the context of a namespace or prefix
     private String url;
     // When the tracking was queued / added to the link checker (UTC)
     private Timestamp created = new Timestamp(new Date().getTime());
     // History stats for this tracker instance
     private final Map<String, CheckedUrlHistoryStats> historyStatsMap =
-            Arrays.stream(HistoryStats.values()).collect(Collectors.toMap(HistoryStats::getKey, historyStats -> historyStats.getFactoryMethod().get()));
+            Arrays.stream(HistoryStatsType.values())
+                    .collect(Collectors.toMap(HistoryStatsType::getKey,
+                            statsType -> statsType.getFactoryMethod().get()));
 
-    public String getUrl() {
-        return url;
-    }
-
-    public HistoryTracker setUrl(String url) {
-        this.url = url;
-        return this;
-    }
-
-    public Timestamp getCreated() {
-        return created;
-    }
-
-    public HistoryTracker setCreated(Timestamp created) {
-        this.created = created;
-        return this;
-    }
-
-    public List<CheckedUrlHistoryStats> getHistoryStats() {
-        return new ArrayList<>(historyStatsMap.values());
-    }
-
-    public CheckedUrlHistoryStats getHistoryStats(HistoryStats historyStatsType) {
+    public CheckedUrlHistoryStats getHistoryStats(HistoryStatsType historyStatsType) {
         return historyStatsMap.get(historyStatsType.getKey());
     }
 
     public void addLinkCheckResult(LinkCheckResult linkCheckResult) {
         // Update the history stats
-        historyStatsMap.values().parallelStream().forEach(checkedUrlHistoryStat -> {checkedUrlHistoryStat.update(linkCheckResult);});
+        historyStatsMap.values().parallelStream().forEach(checkedUrlHistoryStat -> checkedUrlHistoryStat.update(linkCheckResult));
     }
 
     public void initHistoryStats(List<LinkCheckResult> linkCheckResults) {
-        historyStatsMap.values().parallelStream().forEach(checkedUrlHistoryStat -> {checkedUrlHistoryStat.init(linkCheckResults);});
+        historyStatsMap.values().parallelStream().forEach(checkedUrlHistoryStat -> checkedUrlHistoryStat.init(linkCheckResults));
     }
 
-    public enum HistoryStats implements Serializable {
+    @Getter
+    public enum HistoryStatsType implements Serializable {
         SIMPLE(CheckedUrlHistoryStatsSimple::new, "simple", "Simple UP/DOWN history tracking");
 
         private final Supplier<CheckedUrlHistoryStats> factoryMethod;
         private final String key;
         private final String description;
 
-        HistoryStats(Supplier<CheckedUrlHistoryStats> factoryMethod, String key, String description) {
+        HistoryStatsType(Supplier<CheckedUrlHistoryStats> factoryMethod, String key, String description) {
             this.factoryMethod = factoryMethod;
             this.key = key;
             this.description = description;
-        }
-
-        public Supplier<CheckedUrlHistoryStats> getFactoryMethod() {
-            return factoryMethod;
-        }
-
-        public String getKey() {
-            return key;
-        }
-
-        public String getDescription() {
-            return description;
         }
     }
 }

--- a/src/main/java/org/identifiers/cloud/ws/linkchecker/models/ProviderTracker.java
+++ b/src/main/java/org/identifiers/cloud/ws/linkchecker/models/ProviderTracker.java
@@ -1,5 +1,9 @@
 package org.identifiers.cloud.ws.linkchecker.models;
 
+import lombok.Getter;
+import lombok.Setter;
+import lombok.experimental.Accessors;
+
 /**
  * Project: link-checker
  * Package: org.identifiers.cloud.ws.linkchecker.data.models
@@ -11,16 +15,8 @@ package org.identifiers.cloud.ws.linkchecker.models;
  * This class models a scoring entry, at provider level, within the context of a namespace or prefix, i.e. this entity
  * will be used for tracking the provider home URL.
  */
+@Getter @Setter @Accessors(chain = true)
 public class ProviderTracker extends HistoryTracker {
     // Provider ID within the context of a namespace or prefix
     private String id;
-
-    public String getId() {
-        return id;
-    }
-
-    public ProviderTracker setId(String id) {
-        this.id = id;
-        return this;
-    }
 }

--- a/src/main/java/org/identifiers/cloud/ws/linkchecker/models/ResourceTracker.java
+++ b/src/main/java/org/identifiers/cloud/ws/linkchecker/models/ResourceTracker.java
@@ -1,5 +1,9 @@
 package org.identifiers.cloud.ws.linkchecker.models;
 
+import lombok.Getter;
+import lombok.Setter;
+import lombok.experimental.Accessors;
+
 /**
  * Project: link-checker
  * Package: org.identifiers.cloud.ws.linkchecker.models
@@ -8,16 +12,8 @@ package org.identifiers.cloud.ws.linkchecker.models;
  * @author Manuel Bernal Llinares <mbdebian@gmail.com>
  * ---
  */
+@Getter @Setter @Accessors(chain = true)
 public class ResourceTracker extends HistoryTracker {
     // Resource ID within the context of a namespace / prefix
     private String id;
-
-    public String getId() {
-        return id;
-    }
-
-    public ResourceTracker setId(String id) {
-        this.id = id;
-        return this;
-    }
 }

--- a/src/main/java/org/identifiers/cloud/ws/linkchecker/periodictasks/LinkCheckingTask.java
+++ b/src/main/java/org/identifiers/cloud/ws/linkchecker/periodictasks/LinkCheckingTask.java
@@ -81,6 +81,8 @@ public class LinkCheckingTask implements Runnable{
                 if (linkCheckResult != null) { // FIXME: Sometimes a null result here is a result of a check IO error, possibly an offline resource
                     persist(linkCheckResult);
                     announce(linkCheckResult);
+                } else {
+                    logger.info("Failed to attend link check");
                 }
                 linkCheckRequest = nextLinkCheckRequest();
             }

--- a/src/main/java/org/identifiers/cloud/ws/linkchecker/periodictasks/PeriodicChecksFeederTask.java
+++ b/src/main/java/org/identifiers/cloud/ws/linkchecker/periodictasks/PeriodicChecksFeederTask.java
@@ -8,7 +8,6 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
-import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Component;
 
 import java.time.Duration;

--- a/src/main/java/org/identifiers/cloud/ws/linkchecker/services/HistoryTrackingService.java
+++ b/src/main/java/org/identifiers/cloud/ws/linkchecker/services/HistoryTrackingService.java
@@ -6,6 +6,8 @@ import org.identifiers.cloud.ws.linkchecker.models.HistoryTracker;
 import org.identifiers.cloud.ws.linkchecker.models.ProviderTracker;
 import org.identifiers.cloud.ws.linkchecker.models.ResourceTracker;
 
+import java.util.Collection;
+
 /**
  * Project: link-checker
  * Package: org.identifiers.cloud.ws.linkchecker.services
@@ -31,4 +33,6 @@ public interface HistoryTrackingService {
 
     // Attend flushing request received by a sibling service
     void flushHistoryTrackers() throws HistoryTrackingServiceException;
+
+    Collection<ResourceTracker> getAllResourceTrackers();
 }

--- a/src/main/java/org/identifiers/cloud/ws/linkchecker/strategies/LinkCheckerReport.java
+++ b/src/main/java/org/identifiers/cloud/ws/linkchecker/strategies/LinkCheckerReport.java
@@ -1,5 +1,9 @@
 package org.identifiers.cloud.ws.linkchecker.strategies;
 
+import lombok.Getter;
+import lombok.Setter;
+import lombok.experimental.Accessors;
+
 import java.io.Serializable;
 import java.sql.Timestamp;
 
@@ -13,6 +17,7 @@ import java.sql.Timestamp;
  *
  * Report built by a link checking strategy.
  */
+@Getter @Setter @Accessors(chain = true)
 public class LinkCheckerReport implements Serializable {
     // Checked URL
     private String url;
@@ -23,40 +28,4 @@ public class LinkCheckerReport implements Serializable {
     // Checking strategy URL status evaluation. This is an assessment of the checked URL, on whether it is considered to
     // lead to a non-error resource, and it is calculated by the link checking strategy used.
     private boolean urlAssessmentOk = false;
-
-    public String getUrl() {
-        return url;
-    }
-
-    public LinkCheckerReport setUrl(String url) {
-        this.url = url;
-        return this;
-    }
-
-    public Timestamp getTimestamp() {
-        return timestamp;
-    }
-
-    public LinkCheckerReport setTimestamp(Timestamp timestamp) {
-        this.timestamp = timestamp;
-        return this;
-    }
-
-    public int getHttpStatus() {
-        return httpStatus;
-    }
-
-    public LinkCheckerReport setHttpStatus(int httpStatus) {
-        this.httpStatus = httpStatus;
-        return this;
-    }
-
-    public boolean isUrlAssessmentOk() {
-        return urlAssessmentOk;
-    }
-
-    public LinkCheckerReport setUrlAssessmentOk(boolean urlAssessmentOk) {
-        this.urlAssessmentOk = urlAssessmentOk;
-        return this;
-    }
 }

--- a/src/main/java/org/identifiers/cloud/ws/linkchecker/strategies/SimpleLinkCheckerStrategy.java
+++ b/src/main/java/org/identifiers/cloud/ws/linkchecker/strategies/SimpleLinkCheckerStrategy.java
@@ -12,6 +12,7 @@ import java.net.*;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
 import java.sql.Timestamp;
 
 /**
@@ -41,14 +42,13 @@ public class SimpleLinkCheckerStrategy implements LinkCheckerStrategy {
                 .setUrl(checkingUrl.toString())
                 .setTimestamp(new Timestamp(System.currentTimeMillis()));
 
-        URI uri = URI.create(checkingUrl.toString());
-        HttpRequest request = HttpRequest.newBuilder()
-                .method("HEAD", HttpRequest.BodyPublishers.noBody())
-                .uri(uri).build();
         HttpResponse<?> response;
         try {
+            HttpRequest request = HttpRequest.newBuilder()
+                    .method("HEAD", HttpRequest.BodyPublishers.noBody())
+                    .uri(checkingUrl.toURI()).build();
             response = linkCheckerHttpClient.send(request, HttpResponse.BodyHandlers.discarding());
-        } catch (IOException | InterruptedException e) {
+        } catch (IOException | URISyntaxException |InterruptedException e) {
             report.setHttpStatus(HttpStatus.INTERNAL_SERVER_ERROR.value());
             report.setUrlAssessmentOk(false);
             logger.info("[HTTP NaN] Exception when checking {}", report.getUrl());

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -29,8 +29,12 @@ org.identifiers.cloud.ws.linkchecker.requiredrole=${WS_LINK_CHECKER_CONFIG_BACKE
 spring.security.oauth2.resourceserver.jwt.issuer-uri=${WS_LINK_CHECKER_CONFIG_BACKEND_SERVICE_JWT_ISSUERURI:}
 
 ### Spring actuators
+management.endpoints.enabled-by-default=false
 management.endpoints.jmx.exposure.exclude=*
+management.endpoints.web.exposure.include=loggers,health
+
 management.endpoint.loggers.enabled=true
+
 management.endpoint.health.enabled=true
 management.endpoint.health.show-details=when_authorized
 management.endpoint.health.redis.enabled=true
@@ -38,27 +42,3 @@ management.endpoint.health.diskspace.enabled=false
 management.endpoint.health.periodic-checker-thread.enabled=true
 management.endpoint.health.link-checker-thread.enabled=true
 
-management.endpoints.web.exposure.include=loggers,health
-
-# Deactivations for peace of mind - likely unnecessary
-management.endpoint.auditevents.enabled=false
-management.endpoint.beans.enabled=false
-management.endpoint.caches.enabled=false
-management.endpoint.conditions.enabled=false
-management.endpoint.configprops.enabled=false
-management.endpoint.env.enabled=false
-management.endpoint.flyway.enabled=false
-management.endpoint.httptrace.enabled=false
-management.endpoint.info.enabled=false
-management.endpoint.integrationgraph.enabled=false
-management.endpoint.liquibase.enabled=false
-management.endpoint.metrics.enabled=false
-management.endpoint.mappings.enabled=false
-management.endpoint.scheduledtasks.enabled=false
-management.endpoint.sessions.enabled=false
-management.endpoint.shutdown.enabled=false
-management.endpoint.threaddump.enabled=false
-management.endpoint.heapdump.enabled=false
-management.endpoint.jolokia.enabled=false
-management.endpoint.logfile.enabled=false
-management.endpoint.prometheus.enabled=false

--- a/src/test/java/org/identifiers/cloud/ws/linkchecker/api/models/LinkScoringApiModelTest.java
+++ b/src/test/java/org/identifiers/cloud/ws/linkchecker/api/models/LinkScoringApiModelTest.java
@@ -1,0 +1,97 @@
+package org.identifiers.cloud.ws.linkchecker.api.models;
+
+import org.identifiers.cloud.ws.linkchecker.api.requests.ScoringRequestWithIdPayload;
+import org.identifiers.cloud.ws.linkchecker.api.requests.ServiceRequestScoreResource;
+import org.identifiers.cloud.ws.linkchecker.data.models.LinkCheckResult;
+import org.identifiers.cloud.ws.linkchecker.models.ResourceTracker;
+import org.identifiers.cloud.ws.linkchecker.services.HistoryTrackingService;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.List;
+import java.util.Random;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+
+
+class LinkScoringApiModelTest {
+    private static final String RESOURCE_ID = "totally numeric ID";
+    private int expectedScore;
+
+    LinkScoringApiModel model;
+
+
+
+    void setupModelAndMocks(int numValidResults, int numInvalidResults) {
+        expectedScore = Math.round(100.0f*numValidResults/(numValidResults+numInvalidResults));
+
+        HistoryTrackingService historyTrackingService = mock();
+        model = new LinkScoringApiModel(historyTrackingService);
+
+        var invalidResults = IntStream.range(0, numInvalidResults)
+                .mapToObj(i -> new LinkCheckResult().setUrlAssessmentOk(false));
+        var validResults = IntStream.range(0, numValidResults)
+                .mapToObj(i -> new LinkCheckResult().setUrlAssessmentOk(true));
+
+        var resourceTracker = new ResourceTracker();
+        resourceTracker.setId(RESOURCE_ID);
+        resourceTracker.initHistoryStats(Stream.concat(invalidResults, validResults).toList());
+        doReturn(resourceTracker)
+                .when(historyTrackingService)
+                .getTrackerForResource(any());
+        doReturn(List.of(resourceTracker))
+                .when(historyTrackingService)
+                .getAllResourceTrackers();
+    }
+
+
+
+    @ParameterizedTest(name = "valid={0}, invalid={1}")
+    @MethodSource("getRandomParameters")
+    void getScoreForResolvedId(int numValidResults, int numInvalidResults) {
+        setupModelAndMocks(numValidResults, numInvalidResults);
+
+        var request = new ServiceRequestScoreResource();
+        var payload = new ScoringRequestWithIdPayload().setId(RESOURCE_ID);
+        request.setPayload(payload);
+
+        var response = model.getScoreForResolvedId(request);
+        assertEquals(expectedScore, response.getPayload().getScore());
+    }
+
+
+
+    @ParameterizedTest(name = "valid={0}, invalid={1}")
+    @MethodSource("getRandomParameters")
+    void getResourcesIdsWithAvailabilityLowerThan(int numValidResults, int numInvalidResults) {
+        setupModelAndMocks(numValidResults, numInvalidResults);
+
+        var response = model.getResourcesIdsWithAvailabilityLowerThan(expectedScore - 1);
+        assertEquals(0, response.size());
+
+        response = model.getResourcesIdsWithAvailabilityLowerThan(expectedScore + 1);
+        assertEquals(1, response.size());
+
+        var entry = response.entrySet().iterator().next();
+        assertEquals(RESOURCE_ID, entry.getKey());
+        assertTrue(entry.getValue() < expectedScore + 1);
+    }
+
+
+
+    public static Stream<Arguments> getRandomParameters() {
+        var random = new Random();
+        int numArgumentPairs = random.nextInt(10, 20);
+        return IntStream.range(0, numArgumentPairs).mapToObj(i -> Arguments.of(
+          random.nextInt(3, 100), random.nextInt(3, 100)
+        ));
+    }
+}


### PR DESCRIPTION
This is mostly some refactoring to remove linter warnings.

The important part is that checking isn't only recorded for the requested resources, and is now done for every resource. This is needed to query with low availability.